### PR TITLE
docs: fix typo in README litestream example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ nostr relay with backup method using litestream.
       - path: /data/nostr-relay.sqlite
         replicas:
           - type: s3
-            endpoint: https://your-s3-endoint
+            endpoint: https://your-s3-endpoint
             name: nostr-relay.sqlite
             bucket: nostr-relay-backup
             path: nostr-relay.sqlite


### PR DESCRIPTION
Corrects "your-s3-endoint" to "your-s3-endpoint" in the litestream configuration example.