### PR TITLE
Advertise NIP-17 in supported_nips

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 	_ relayer.Logger        = (*Relay)(nil)
 	_ relayer.Auther        = (*Relay)(nil)
 
-	supportedNIPs = []any{1, 2, 4, 9, 11, 12, 15, 16, 20, 22, 26, 28, 33, 40, 42, 45, 50, 59, 65, 70, 77}
+	supportedNIPs = []any{1, 2, 4, 9, 11, 12, 15, 16, 17, 20, 22, 26, 28, 33, 40, 42, 45, 50, 59, 65, 70, 77}
 
 	//go:embed static
 	assets embed.FS


### PR DESCRIPTION
Add 17 to supported_nips. The relayer framework already provides the relay-side behavior NIP-17 requires (kind 1059 gift wraps are stored and only served to the NIP-42-authenticated recipient), so clients checking NIP-11 for DM relay support can now pick this relay.