### PR TITLE
Treat out-of-range filter values as no-match and quiet ping-disconnect noise

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -428,6 +428,15 @@ func (r *Relay) Errorf(format string, v ...any) {
 	case strings.Contains(msg, "too many kinds"):
 		slog.Warn(msg)
 		return
+	case strings.HasPrefix(msg, "error writing ping:"):
+		// the client went away between two keepalives, which is ordinary churn on
+		// a public relay rather than a fault. Matched by prefix on purpose: the
+		// wrapped cause is a bare *net.OpError ("broken pipe", "connection reset
+		// by peer", "use of closed network connection") that the storage backends
+		// report verbatim too, so matching the cause would also silence a dead
+		// database.
+		slog.Debug(msg)
+		return
 	}
 	slog.Error(msg)
 }

--- a/relay.go
+++ b/relay.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -106,16 +107,19 @@ type relayStore struct {
 
 func (s *relayStore) BeforeSave(ctx context.Context, evt *nostr.Event) {}
 
-// sanitizeFilter reconciles empty tag sets, which the underlying backends reject
-// as errors, with go-nostr's Filter.Matches semantics:
+// sanitizeFilter reconciles filter shapes that the underlying backends reject as
+// errors with go-nostr's Filter.Matches semantics:
 //
 //   - a non-nil but empty value list (e.g. {"#e": []}) can never match any event,
 //     so the filter is unsatisfiable and the caller should return no results;
 //   - a nil value list (e.g. {"#e": null}) is treated as no constraint, so the tag
 //     entry is dropped before the filter reaches the backend (which would otherwise
-//     fail the whole query with "empty tag set").
+//     fail the whole query with "empty tag set");
+//   - since/until/kinds outside the 32-bit range of the sql `created_at` and `kind`
+//     columns are rewritten by sanitizeCreatedAt/sanitizeKinds below, which would
+//     otherwise fail the whole query with "out of range for type integer".
 //
-// It returns the (possibly tag-pruned) filter and whether it is unsatisfiable.
+// It returns the (possibly rewritten) filter and whether it is unsatisfiable.
 func sanitizeFilter(filter nostr.Filter) (nostr.Filter, bool) {
 	hasNil := false
 	for _, values := range filter.Tags {
@@ -136,6 +140,73 @@ func sanitizeFilter(filter nostr.Filter) (nostr.Filter, bool) {
 		}
 		filter.Tags = cleaned
 	}
+	filter, unsatisfiable := sanitizeCreatedAt(filter)
+	if unsatisfiable {
+		return filter, true
+	}
+	return sanitizeKinds(filter)
+}
+
+// sanitizeCreatedAt rewrites since/until that fall outside the range of the sql
+// `created_at` column, which the postgresql and mysql backends declare as a 32-bit
+// `integer` and bind the raw filter timestamp against. go-nostr's Timestamp is an
+// int64 and is decoded without a range check, so a client can send a value the
+// column cannot hold; postgresql then fails the entire query with
+// "out of range for type integer" (sqlstate 22003) rather than returning no rows.
+//
+// Because no stored row can hold a created_at outside that range, both rewrites are
+// exact rather than approximate:
+//
+//   - since > max (or until < min) can never be satisfied, so the filter is
+//     unsatisfiable and the caller should return no results;
+//   - since < min (or until > max) is satisfied by every row, so the bound is no
+//     constraint at all and is dropped before the filter reaches the backend.
+func sanitizeCreatedAt(filter nostr.Filter) (nostr.Filter, bool) {
+	if filter.Since != nil {
+		switch since := int64(*filter.Since); {
+		case since > math.MaxInt32:
+			return filter, true
+		case since < math.MinInt32:
+			filter.Since = nil
+		}
+	}
+	if filter.Until != nil {
+		switch until := int64(*filter.Until); {
+		case until < math.MinInt32:
+			return filter, true
+		case until > math.MaxInt32:
+			filter.Until = nil
+		}
+	}
+	return filter, false
+}
+
+// sanitizeKinds drops kinds that fall outside the range of the sql `kind` column,
+// which has the same 32-bit width and the same unchecked binding as `created_at`
+// (see sanitizeCreatedAt). No stored row can hold such a kind, so dropping one only
+// removes an alternative that could never match — but dropping every kind of a
+// non-empty list leaves a filter that can match nothing, which is unsatisfiable
+// rather than unconstrained.
+func sanitizeKinds(filter nostr.Filter) (nostr.Filter, bool) {
+	inRange := 0
+	for _, kind := range filter.Kinds {
+		if kind >= math.MinInt32 && kind <= math.MaxInt32 {
+			inRange++
+		}
+	}
+	if inRange == len(filter.Kinds) {
+		return filter, false
+	}
+	if inRange == 0 {
+		return filter, true
+	}
+	cleaned := make([]int, 0, inRange)
+	for _, kind := range filter.Kinds {
+		if kind >= math.MinInt32 && kind <= math.MaxInt32 {
+			cleaned = append(cleaned, kind)
+		}
+	}
+	filter.Kinds = cleaned
 	return filter, false
 }
 

--- a/relay_test.go
+++ b/relay_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"math"
 	"slices"
 	"testing"
@@ -220,6 +221,75 @@ func TestRelayStoreCountEventsSanitizesBeforeBackend(t *testing.T) {
 		t.Errorf("unsatisfiable filter was forwarded to the backend: %+v", backend.counted[1:])
 	}
 }
+
+// Errorf is the sink for both websocket keepalive failures and storage failures.
+// Quieting the former must not quiet the latter: the underlying *net.OpError text
+// is identical, so only the ping message's own prefix may be downgraded.
+func TestErrorfDowngradesOnlyPingWriteFailures(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		args   []any
+		want   slog.Level
+	}{
+		{
+			name:   "ping write failure",
+			format: "error writing ping: %v; closing websocket",
+			args:   []any{"set tcp 172.25.0.3:7447: use of closed network connection"},
+			want:   slog.LevelDebug,
+		},
+		{
+			name:   "storage failure with the same underlying cause",
+			format: "store: %v",
+			args:   []any{"write tcp 10.0.0.2:52344->10.0.0.5:5432: write: broken pipe"},
+			want:   slog.LevelError,
+		},
+		{
+			name:   "storage failure on a reset backend connection",
+			format: "store: %v",
+			args:   []any{"read tcp 10.0.0.2:52344->10.0.0.5:5432: connection reset by peer"},
+			want:   slog.LevelError,
+		},
+		{
+			name:   "too many kinds stays a warning",
+			format: "store: %v",
+			args:   []any{"too many kinds"},
+			want:   slog.LevelWarn,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &recordingHandler{}
+			restore := slog.Default()
+			slog.SetDefault(slog.New(rec))
+			defer slog.SetDefault(restore)
+
+			(&Relay{}).Errorf(tt.format, tt.args...)
+
+			if len(rec.levels) != 1 {
+				t.Fatalf("logged %d records, want 1", len(rec.levels))
+			}
+			if rec.levels[0] != tt.want {
+				t.Errorf("logged at %v, want %v", rec.levels[0], tt.want)
+			}
+		})
+	}
+}
+
+type recordingHandler struct {
+	levels []slog.Level
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.levels = append(h.levels, r.Level)
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(string) slog.Handler      { return h }
 
 func equalTimestamp(got, want *nostr.Timestamp) bool {
 	if got == nil || want == nil {

--- a/relay_test.go
+++ b/relay_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"context"
+	"math"
+	"slices"
+	"testing"
+
+	"github.com/nbd-wtf/go-nostr"
+)
+
+func timestamp(v int64) *nostr.Timestamp {
+	ts := nostr.Timestamp(v)
+	return &ts
+}
+
+// recordingStore is a minimal eventstore.Store (plus eventstore.Counter) that
+// captures the filter it was handed, so a test can assert what actually reached
+// the backend rather than what a helper returned.
+type recordingStore struct {
+	queried []nostr.Filter
+	counted []nostr.Filter
+}
+
+func (s *recordingStore) Init() error { return nil }
+func (s *recordingStore) Close()      {}
+
+func (s *recordingStore) QueryEvents(_ context.Context, filter nostr.Filter) (chan *nostr.Event, error) {
+	s.queried = append(s.queried, filter)
+	ch := make(chan *nostr.Event)
+	close(ch)
+	return ch, nil
+}
+
+func (s *recordingStore) CountEvents(_ context.Context, filter nostr.Filter) (int64, error) {
+	s.counted = append(s.counted, filter)
+	return 0, nil
+}
+
+func (s *recordingStore) DeleteEvent(context.Context, *nostr.Event) error  { return nil }
+func (s *recordingStore) SaveEvent(context.Context, *nostr.Event) error    { return nil }
+func (s *recordingStore) ReplaceEvent(context.Context, *nostr.Event) error { return nil }
+
+// A since/until the sql `created_at` column cannot hold used to fail the whole
+// query with "out of range for type integer" (sqlstate 22003) on the postgresql
+// backend. No stored row can hold such a value, so an unreachable bound must come
+// back as no-match and an always-true bound must be dropped — never forwarded.
+func TestSanitizeFilterRewritesOutOfRangeCreatedAt(t *testing.T) {
+	tests := []struct {
+		name          string
+		filter        nostr.Filter
+		unsatisfiable bool
+		wantSince     *nostr.Timestamp
+		wantUntil     *nostr.Timestamp
+	}{
+		{
+			name:          "since above column max can never match",
+			filter:        nostr.Filter{Since: timestamp(9_999_999_999)},
+			unsatisfiable: true,
+		},
+		{
+			name:          "until below column min can never match",
+			filter:        nostr.Filter{Until: timestamp(-9_999_999_999)},
+			unsatisfiable: true,
+		},
+		{
+			name:      "since below column min is no constraint",
+			filter:    nostr.Filter{Since: timestamp(-9_999_999_999)},
+			wantSince: nil,
+		},
+		{
+			name:      "until above column max is no constraint",
+			filter:    nostr.Filter{Until: timestamp(9_999_999_999)},
+			wantUntil: nil,
+		},
+		{
+			name:      "in-range bounds are untouched",
+			filter:    nostr.Filter{Since: timestamp(1_700_000_000), Until: timestamp(1_800_000_000)},
+			wantSince: timestamp(1_700_000_000),
+			wantUntil: timestamp(1_800_000_000),
+		},
+		{
+			name:      "the column bounds themselves are in range",
+			filter:    nostr.Filter{Since: timestamp(math.MinInt32), Until: timestamp(math.MaxInt32)},
+			wantSince: timestamp(math.MinInt32),
+			wantUntil: timestamp(math.MaxInt32),
+		},
+		{
+			name:   "absent bounds stay absent",
+			filter: nostr.Filter{Kinds: []int{1}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, unsatisfiable := sanitizeFilter(tt.filter)
+			if unsatisfiable != tt.unsatisfiable {
+				t.Fatalf("unsatisfiable = %v, want %v", unsatisfiable, tt.unsatisfiable)
+			}
+			if unsatisfiable {
+				return
+			}
+			if !equalTimestamp(got.Since, tt.wantSince) {
+				t.Errorf("Since = %v, want %v", showTimestamp(got.Since), showTimestamp(tt.wantSince))
+			}
+			if !equalTimestamp(got.Until, tt.wantUntil) {
+				t.Errorf("Until = %v, want %v", showTimestamp(got.Until), showTimestamp(tt.wantUntil))
+			}
+		})
+	}
+}
+
+// `kind` is the same 32-bit sql column with the same unchecked binding as
+// `created_at`, so it overflows the same way.
+func TestSanitizeFilterRewritesOutOfRangeKinds(t *testing.T) {
+	tests := []struct {
+		name          string
+		kinds         []int
+		unsatisfiable bool
+		want          []int
+	}{
+		{
+			name:          "every kind out of range can never match",
+			kinds:         []int{9_999_999_999, -9_999_999_999},
+			unsatisfiable: true,
+		},
+		{
+			name:  "out-of-range kinds are dropped from a mixed list",
+			kinds: []int{1, 9_999_999_999, 7},
+			want:  []int{1, 7},
+		},
+		{
+			name:  "in-range kinds are untouched",
+			kinds: []int{0, 1, 30023},
+			want:  []int{0, 1, 30023},
+		},
+		{
+			name:  "the column bounds themselves are in range",
+			kinds: []int{math.MinInt32, math.MaxInt32},
+			want:  []int{math.MinInt32, math.MaxInt32},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, unsatisfiable := sanitizeFilter(nostr.Filter{Kinds: tt.kinds})
+			if unsatisfiable != tt.unsatisfiable {
+				t.Fatalf("unsatisfiable = %v, want %v", unsatisfiable, tt.unsatisfiable)
+			}
+			if unsatisfiable {
+				return
+			}
+			if !slices.Equal(got.Kinds, tt.want) {
+				t.Errorf("Kinds = %v, want %v", got.Kinds, tt.want)
+			}
+		})
+	}
+}
+
+// The sanitizing has to reach the backend through the store wrapper, not just be
+// correct in isolation: this is the REQ leg, and it is the wiring that a future
+// refactor could silently drop while every helper-level test above stayed green.
+func TestRelayStoreQueryEventsSanitizesBeforeBackend(t *testing.T) {
+	backend := &recordingStore{}
+	store := &relayStore{Store: backend}
+
+	if _, err := store.QueryEvents(context.Background(), nostr.Filter{
+		Kinds: []int{1},
+		Until: timestamp(9_999_999_999),
+	}); err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	if len(backend.queried) != 1 {
+		t.Fatalf("backend saw %d queries, want 1", len(backend.queried))
+	}
+	if backend.queried[0].Until != nil {
+		t.Errorf("out-of-range Until reached the backend: %v", *backend.queried[0].Until)
+	}
+
+	ch, err := store.QueryEvents(context.Background(), nostr.Filter{Since: timestamp(9_999_999_999)})
+	if err != nil {
+		t.Fatalf("QueryEvents: %v", err)
+	}
+	if _, ok := <-ch; ok {
+		t.Error("unsatisfiable filter returned an event")
+	}
+	if len(backend.queried) != 1 {
+		t.Errorf("unsatisfiable filter was forwarded to the backend: %+v", backend.queried[1:])
+	}
+}
+
+// COUNT is the leg that a filter hook on the REQ path cannot reach: relayer's
+// doCount never calls AcceptReq, so NIP-45 must be sanitized in the store wrapper
+// to be covered at all.
+func TestRelayStoreCountEventsSanitizesBeforeBackend(t *testing.T) {
+	backend := &recordingStore{}
+	store := &relayStore{Store: backend}
+
+	if _, err := store.CountEvents(context.Background(), nostr.Filter{
+		Kinds: []int{1},
+		Until: timestamp(9_999_999_999),
+	}); err != nil {
+		t.Fatalf("CountEvents: %v", err)
+	}
+	if len(backend.counted) != 1 {
+		t.Fatalf("backend saw %d counts, want 1", len(backend.counted))
+	}
+	if backend.counted[0].Until != nil {
+		t.Errorf("out-of-range Until reached the backend: %v", *backend.counted[0].Until)
+	}
+
+	count, err := store.CountEvents(context.Background(), nostr.Filter{Since: timestamp(9_999_999_999)})
+	if err != nil {
+		t.Fatalf("CountEvents: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("unsatisfiable filter counted %d, want 0", count)
+	}
+	if len(backend.counted) != 1 {
+		t.Errorf("unsatisfiable filter was forwarded to the backend: %+v", backend.counted[1:])
+	}
+}
+
+func equalTimestamp(got, want *nostr.Timestamp) bool {
+	if got == nil || want == nil {
+		return got == nil && want == nil
+	}
+	return *got == *want
+}
+
+func showTimestamp(ts *nostr.Timestamp) any {
+	if ts == nil {
+		return nil
+	}
+	return *ts
+}


### PR DESCRIPTION
## Summary

Two unrelated production problems on `nostr.relay.hedwig.sh` (postgresql backend), one commit each.

1. **`REQ`/`COUNT` filters carrying values the sql columns cannot hold failed the whole query** with `pq: value ... is out of range for type integer` (sqlstate **22003**) instead of returning no rows.
2. **Ping-write failures were logged at ERROR.** A client that disappears between two keepalives is ordinary churn on a public relay, and it accounted for 1743 of 1854 ERROR lines over 48h.

## Root cause

`created_at` and `kind` are 32-bit sql `integer` in the postgresql and mysql schemas, and the backends bind the raw filter values straight against them. go-nostr decodes `since`/`until` as `int64` and `kinds` as `int` with no range check, so any of the following reaches the column as a value it cannot represent:

| input | before |
|---|---|
| `{"since": 9999999999}` | 22003 |
| `{"since": -9999999999}` | 22003 |
| `{"until": ±9999999999}` | 22003 |
| `{"kinds": [9999999999]}` | 22003 |

sqlite3 stores `integer` as a 64-bit dynamic type and does not error, so this is postgresql/mysql-specific.

## What the fix does

**Filters** — extends `sanitizeFilter`, which already reconciles empty tag sets and is applied on **both** `relayStore.QueryEvents` and `relayStore.CountEvents`. That placement is what makes NIP-45 `COUNT` covered: relayer's `doCount` never calls `AcceptReq`, so a hook on the `REQ` path alone cannot reach it.

Because no stored row can hold an out-of-range value, every rewrite is exact rather than approximate — no filter semantics change:

- `since` above the column max (and `until` below its min) can never be satisfied → the filter is **unsatisfiable**, return no rows
- `since` below the min (and `until` above the max) is satisfied by every row → the bound is **no constraint**, drop it
- an out-of-range `kind` only removes an alternative that could not match → **drop it**; if it was the only one, the filter can match nothing → unsatisfiable

**Logging** — matches the `"error writing ping:"` prefix rather than the wrapped cause. The cause is a bare `*net.OpError`, and `lib/pq` returns the same one verbatim for a dead backend connection (`handleError` does not rewrite it for `*net.OpError`). Matching `broken pipe` / `connection reset by peer` / `use of closed network connection` would therefore also silence the two `Errorf("store: %v", err)` call sites that report a database outage — and invisibly, since the default log level is `info`.

## Log evidence (nostr.relay.hedwig.sh, postgresql backend)

**Before** (v0.0.240 fork, 48h window):

```
ERROR  store: failed to fetch events using query "SELECT id, pubkey, created_at, kind, tags, content, sig FROM event WHERE kind IN ($1) AND created_at >= $2 ORDER BY created_at DESC, id LIMIT $3": pq: value "9999999999" is out of range for type integer (22003)
ERROR  error writing ping: set tcp 172.25.0.3:7447: use of closed network connection; closing websocket
```

Error taxonomy (48h): `1733x` ping "use of closed network connection"; `99x` "store: too many tag values"; `10x` ping closed-conn; `7x` "broken pipe"; `5x` "connection reset by peer".

**After** (~30m window):

```
ERROR-level lines: 1   error-writing-ping: 0   out-of-range/22003: 0
live probe ["REQ",{"kinds":[1],"since":9999999999,"limit":5}] -> events=0 EOSE=1   (previously: 22003 query failure)
```

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green (go 1.26.0)
- [x] Every new test verified to **fail** against unpatched `relay.go`, not merely to pass against the fix
- [x] `sanitizeFilter` covered for both bounds of `since`/`until`, for `kinds`, and for the boundary values `math.MinInt32`/`math.MaxInt32` themselves
- [x] The **wiring** is pinned, not just the helper: `TestRelayStoreQueryEventsSanitizesBeforeBackend` and `TestRelayStoreCountEventsSanitizesBeforeBackend` drive the real `relayStore` call sites through a recording `eventstore.Store` and assert what the backend actually received
- [x] `TestErrorfDowngradesOnlyPingWriteFailures` asserts a storage error carrying the *identical* `*net.OpError` text still logs at ERROR — it fails against the broad-substring approach
- [x] Live on nostr.relay.hedwig.sh
