### PR TITLE
Advertise NIP-66 support

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 	_ relayer.Logger        = (*Relay)(nil)
 	_ relayer.Auther        = (*Relay)(nil)
 
-	supportedNIPs = []any{1, 4, 9, 11, 17, 26, 40, 42, 45, 50, 59, 70, 78}
+	supportedNIPs = []any{1, 4, 9, 11, 17, 26, 40, 42, 45, 50, 59, 66, 70, 78}
 
 	//go:embed static
 	assets embed.FS


### PR DESCRIPTION
Advertise NIP-66 support for addressable relay discovery events. See https://github.com/nostr-protocol/nips/blob/master/66.md.