### PR TITLE
Update relayer to v2.2.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.5.0
 	github.com/fiatjaf/eventstore v0.17.12
-	github.com/fiatjaf/relayer/v2 v2.2.17
+	github.com/fiatjaf/relayer/v2 v2.2.18
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nbd-wtf/go-nostr v0.52.3

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeO
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/fiatjaf/eventstore v0.17.12 h1:U5sjiDPtbsj88utSK0gDJ7PtgaSBmUnwpsZi+T1C6GI=
 github.com/fiatjaf/eventstore v0.17.12/go.mod h1:TgVcdIfGnRz5rDoZfb4Fb99DWDoCnbYauUoHEe2OcA8=
-github.com/fiatjaf/relayer/v2 v2.2.17 h1:T8hdNbLjklvwK7dK0u+U5odCYRp9AmOD/UMOxMmKCoU=
-github.com/fiatjaf/relayer/v2 v2.2.17/go.mod h1:JGecfj+NKIZLYWnSxus0ss156YQNMDX7p44DLBY/W0I=
+github.com/fiatjaf/relayer/v2 v2.2.18 h1:ejGlrOg8D+2bPW6FpmbJPLvgoaciCxvMbhlcsozutCc=
+github.com/fiatjaf/relayer/v2 v2.2.18/go.mod h1:JGecfj+NKIZLYWnSxus0ss156YQNMDX7p44DLBY/W0I=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
Update relayer to v2.2.18 so explicit limit: 0 filters skip history, emit EOSE, and remain subscribed for live events as clarified by https://github.com/nostr-protocol/nips/pull/2460.