### PR TITLE
Add a /gc endpoint that returns free memory to the OS

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,23 +144,6 @@ func main() {
 	}
 
 	if envDef("ENABLE_PPROF", "no") == "yes" {
-		// /gc runs a full GC and returns the freed spans to the OS, so that
-		// RSS can be told apart from a real leak: memory the runtime was only
-		// holding for reuse goes away here, memory that is still reachable
-		// does not. It shares the pprof listener because a stop-the-world
-		// collection is not something an unauthenticated caller on the relay
-		// port should be able to trigger at will.
-		http.HandleFunc("/gc", func(w http.ResponseWriter, req *http.Request) {
-			var before, after runtime.MemStats
-			runtime.ReadMemStats(&before)
-			debug.FreeOSMemory()
-			runtime.ReadMemStats(&after)
-			w.Header().Set("content-type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{
-				"before": memSnapshot(&before),
-				"after":  memSnapshot(&after),
-			})
-		})
 		go func() {
 			log.Println(http.ListenAndServe("0.0.0.0:6060", nil))
 		}()
@@ -250,6 +233,21 @@ func main() {
 	})
 	server.Router().HandleFunc("/reload", func(w http.ResponseWriter, req *http.Request) {
 		r.reload()
+	})
+	// /gc runs a full collection and returns the free spans to the OS, so that
+	// resident memory can be told apart from a real leak: what the runtime was
+	// only holding for reuse goes away here, what is still reachable does not.
+	// The MemStats on either side say which of the two happened.
+	server.Router().HandleFunc("/gc", func(w http.ResponseWriter, req *http.Request) {
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		debug.FreeOSMemory()
+		runtime.ReadMemStats(&after)
+		w.Header().Add("content-type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"before": memSnapshot(&before),
+			"after":  memSnapshot(&after),
+		})
 	})
 	server.Router().Handle("/", http.FileServer(http.FS(sub)))
 

--- a/main.go
+++ b/main.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -97,6 +99,21 @@ func skipEventFunc(ev *nostr.Event) bool {
 	return false
 }
 
+// memSnapshot picks the counters that separate live objects from memory the
+// runtime is merely holding on to.
+func memSnapshot(m *runtime.MemStats) map[string]uint64 {
+	return map[string]uint64{
+		"sys":           m.Sys,
+		"heap_alloc":    m.HeapAlloc,
+		"heap_sys":      m.HeapSys,
+		"heap_idle":     m.HeapIdle,
+		"heap_inuse":    m.HeapInuse,
+		"heap_released": m.HeapReleased,
+		"heap_objects":  m.HeapObjects,
+		"num_gc":        uint64(m.NumGC),
+	}
+}
+
 func main() {
 	var r Relay
 	var ver bool
@@ -127,6 +144,23 @@ func main() {
 	}
 
 	if envDef("ENABLE_PPROF", "no") == "yes" {
+		// /gc runs a full GC and returns the freed spans to the OS, so that
+		// RSS can be told apart from a real leak: memory the runtime was only
+		// holding for reuse goes away here, memory that is still reachable
+		// does not. It shares the pprof listener because a stop-the-world
+		// collection is not something an unauthenticated caller on the relay
+		// port should be able to trigger at will.
+		http.HandleFunc("/gc", func(w http.ResponseWriter, req *http.Request) {
+			var before, after runtime.MemStats
+			runtime.ReadMemStats(&before)
+			debug.FreeOSMemory()
+			runtime.ReadMemStats(&after)
+			w.Header().Set("content-type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"before": memSnapshot(&before),
+				"after":  memSnapshot(&after),
+			})
+		})
 		go func() {
 			log.Println(http.ListenAndServe("0.0.0.0:6060", nil))
 		}()


### PR DESCRIPTION
Resident memory kept drifting up while the live heap stayed flat, and there was no way to tell memory the runtime was merely holding for reuse from memory that is still reachable. /gc runs a full collection, scavenges the free spans back to the OS and reports MemStats on either side, so one request answers the question: what the runtime was only holding goes away, what is still live does not. It sits on the relay router next to /info and /reload.