### PR TITLE
Update relayer to v2.2.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.5.0
 	github.com/fiatjaf/eventstore v0.17.13
-	github.com/fiatjaf/relayer/v2 v2.2.19
+	github.com/fiatjaf/relayer/v2 v2.2.20
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nbd-wtf/go-nostr v0.52.3

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeO
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/fiatjaf/eventstore v0.17.13 h1:oqzRvLli68uSPw/IUJxmLTcbzl7Igy1CfMfA6RJ3AX8=
 github.com/fiatjaf/eventstore v0.17.13/go.mod h1:TgVcdIfGnRz5rDoZfb4Fb99DWDoCnbYauUoHEe2OcA8=
-github.com/fiatjaf/relayer/v2 v2.2.19 h1:Hs3aZ7ySSOArQXTh8hqkMp5FVmVEBe2xUWrOGWAvUUg=
-github.com/fiatjaf/relayer/v2 v2.2.19/go.mod h1:JGecfj+NKIZLYWnSxus0ss156YQNMDX7p44DLBY/W0I=
+github.com/fiatjaf/relayer/v2 v2.2.20 h1:/sU7eX+itMJnM/3mXZj+OjMchFjat+g0gsJNIHTd3ko=
+github.com/fiatjaf/relayer/v2 v2.2.20/go.mod h1:JGecfj+NKIZLYWnSxus0ss156YQNMDX7p44DLBY/W0I=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
relayer v2.2.20 stops a disconnected client's listener from being registered again. doReq registers the subscription only after streaming the history, so a client that went away while the query was still running had its cleanup run first and the registration land afterwards, with nothing left to remove it. The filters stayed reachable for the life of the process.

Reproduced against v2.2.19 and confirmed fixed: fiatjaf/relayer#161. In production 15.5% of REQs are followed by a disconnect within 5 seconds, which is the window this races with.