### PR TITLE
Update relayer to v2.2.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.5.0
 	github.com/fiatjaf/eventstore v0.17.13
-	github.com/fiatjaf/relayer/v2 v2.2.20
+	github.com/fiatjaf/relayer/v2 v2.2.21
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nbd-wtf/go-nostr v0.52.3

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeO
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/fiatjaf/eventstore v0.17.13 h1:oqzRvLli68uSPw/IUJxmLTcbzl7Igy1CfMfA6RJ3AX8=
 github.com/fiatjaf/eventstore v0.17.13/go.mod h1:TgVcdIfGnRz5rDoZfb4Fb99DWDoCnbYauUoHEe2OcA8=
-github.com/fiatjaf/relayer/v2 v2.2.20 h1:/sU7eX+itMJnM/3mXZj+OjMchFjat+g0gsJNIHTd3ko=
-github.com/fiatjaf/relayer/v2 v2.2.20/go.mod h1:JGecfj+NKIZLYWnSxus0ss156YQNMDX7p44DLBY/W0I=
+github.com/fiatjaf/relayer/v2 v2.2.21 h1:vJWXjmcHXGaE66xfV65s4Dnmn2x3aa3MsZZjWKvFV9Q=
+github.com/fiatjaf/relayer/v2 v2.2.21/go.mod h1:JGecfj+NKIZLYWnSxus0ss156YQNMDX7p44DLBY/W0I=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
relayer v2.2.21 stops a pending history query from restoring a subscription that was closed, and from overwriting a newer REQ that reused the same id. The first kept a CLOSE'd subscription's filters reachable until the connection went away; the second delivered events matching the older filters. Follow-up to v2.2.20, which covered the same race across a disconnect.

Reproduced both against v2.2.20 and confirmed fixed over a real websocket: fiatjaf/relayer#162.